### PR TITLE
fix pydantic version error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ requests==2.28.1
 termcolor==2.1.1
 websocket_client==1.5.1
 openai==0.27.8
-pydantic==2.0.2
+pydantic==2.1.1
 dulwich==0.21.5
-litellm==0.1.226
+litellm==0.1.354

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ websocket_client==1.5.1
 openai==0.27.8
 pydantic==2.1.1
 dulwich==0.21.5
-litellm==0.1.354
+litellm==0.1.356


### PR DESCRIPTION
⚠️ **Notice**: Apply a label to this pull request in one the following three labels: 👉

- `bug`: Fix something isn't working
- `enhancement`: Enhance existing features
- `feature`: Add brand new features

Addressing https://github.com/iuiaoin/wechat-gptbot/issues/79#issuecomment-1668855769 

Looks like it was caused because anthropic uses pydantic ModelField https://github.com/pydantic/pydantic/blob/5e7d43e0269c6118f63a02bad04328b61e8bfe69/pydantic/v1/fields.py#L365

- This fix bumps the version of pydantic used by wechat-gptbot
- bumps the version of litellm used, litellm now requires a pydantic version of 2.1.1
- I'm working on making litellm have less dependencies - it should only try installing anthropic if a user is using it (this would prevent errors seen in the above issue) 
